### PR TITLE
ci(package-publishing-script): update package publishing script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,24 @@
 name: Publish Package
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      Version:
+        description: "Version to be released in format: x.y.z, where x => major version, y => minor version and z => patch version"
+        required: true
+        default: "0.1.0"
+      Title:
+        description: "Title of the release"
+        required: true
+        default: "Improving API developer experience"
 
 jobs:
   publish-package:
+    environment: Production
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -18,6 +31,22 @@ jobs:
           python -m build
           twine check --strict dist/*
       - name: Publish distribution to PyPI
+        id: release
         uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+      - name: Create tag
+        if: steps.release.outputs.exit_code == 0
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.TAGS_TOKEN }}
+          custom_tag: ${{ github.event.inputs.Version }}
+          tag_prefix: ""
+      - name: Create changelog for the release
+        if: steps.release.outputs.exit_code == 0
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ github.event.inputs.Title }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
This PR bears the change in the script used for pypi package publishing. The improvements made in this commit are that job will use the production environment and will create the tags and changelogs automatically.

closes #7