### PR TITLE
fix(method-definition): add missing request parameter in method

### DIFF
--- a/apimatic_core_interfaces/client/http_client.py
+++ b/apimatic_core_interfaces/client/http_client.py
@@ -25,13 +25,14 @@ class HttpClient(ABC):
         ...
 
     @abstractmethod
-    def convert_response(self, response, contains_binary_response):
+    def convert_response(self, response, contains_binary_response, request):
         """Converts the Response object of the HttpClient into an
         HttpResponse object.
 
         Args:
             response (dynamic): The original response object.
             contains_binary_response (bool): The flag to check if the response is of binary type.
+            request (HttpRequest): The original HttpRequest object.
 
         Returns:
             HttpResponse: The converted HttpResponse object.


### PR DESCRIPTION
This PR bears the fix for the method definition in HttpClient class where convert_response method has a parameter missing in the definition. This change adds a request parameter of type HttpRequest in the method definition.

closes #10