### PR TITLE
feat(union-types): adds support for OneOf and AnyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ pip install apimatic-core-interfaces
 ```
 
 ## Interfaces
-| Name                                                                       | Description                                                                              |
-|--------------------------------------------------------------------------- |------------------------------------------------------------------------------------------|
-| [`HttpClient`](apimatic_core_interfaces/client/http_client.py)             | To save both Request and Response after the completion of response                         |
-| [`ResponseFactory`](apimatic_core_interfaces/factories/response_factory.py)| To convert the client-adapter response into a custom HTTP response                       |
-| [`Authentication`](apimatic_core_interfaces/types/authentication.py)       | To setup methods for the validation and application of the required authentication scheme|
+| Name                                                                        | Description                                                                               |
+|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| [`HttpClient`](apimatic_core_interfaces/client/http_client.py)              | To save both Request and Response after the completion of response                        |
+| [`ResponseFactory`](apimatic_core_interfaces/factories/response_factory.py) | To convert the client-adapter response into a custom HTTP response                        |
+| [`Authentication`](apimatic_core_interfaces/types/authentication.py)        | To setup methods for the validation and application of the required authentication scheme |
+| [`UnionType`](apimatic_core_interfaces/types/union_type.py)                 | To setup methods for the validation and deserialization of OneOf/AnyOf union types        |
 
 
 ## Enumerations

--- a/apimatic_core_interfaces/types/__init__.py
+++ b/apimatic_core_interfaces/types/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
     'http_method_enum',
-    'authentication'
+    'authentication',
+    'union_type'
 ]

--- a/apimatic_core_interfaces/types/union_type.py
+++ b/apimatic_core_interfaces/types/union_type.py
@@ -8,6 +8,7 @@ class UnionType(ABC):
         self._union_types = union_types
         self._union_type_context = union_type_context
         self.is_valid = False
+        self.errors = []
 
     @abstractmethod
     def validate(self, value):

--- a/apimatic_core_interfaces/types/union_type.py
+++ b/apimatic_core_interfaces/types/union_type.py
@@ -3,8 +3,6 @@ from abc import ABC, abstractmethod
 
 class UnionType(ABC):
     NATIVE_TYPES = [int, str, float, bool]
-    NONE_MATCHED_ERROR_MESSAGE = 'We could not match any acceptable types against the given JSON.'
-    MORE_THAN_1_MATCHED_ERROR_MESSAGE = 'There are more than one acceptable type matched against the given JSON.'
 
     def __init__(self, union_types, union_type_context):
         self._union_types = union_types

--- a/apimatic_core_interfaces/types/union_type.py
+++ b/apimatic_core_interfaces/types/union_type.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
-from apimatic_core.types.union_types.union_type_context import UnionTypeContext
 
 
 class UnionType(ABC):
     NATIVE_TYPES = [int, str, float, bool]
 
-    def __init__(self, union_types, union_type_context: UnionTypeContext):
+    def __init__(self, union_types, union_type_context):
         self._union_types = union_types
         self._union_type_context = union_type_context
         self.is_valid = False
@@ -17,3 +16,6 @@ class UnionType(ABC):
     @abstractmethod
     def deserialize(self, value):
         ...
+
+    def get_context(self):
+        return self._union_type_context

--- a/apimatic_core_interfaces/types/union_type.py
+++ b/apimatic_core_interfaces/types/union_type.py
@@ -3,12 +3,14 @@ from abc import ABC, abstractmethod
 
 class UnionType(ABC):
     NATIVE_TYPES = [int, str, float, bool]
+    NONE_MATCHED_ERROR_MESSAGE = 'We could not match any acceptable types against the given JSON.'
+    MORE_THAN_1_MATCHED_ERROR_MESSAGE = 'There are more than one acceptable type matched against the given JSON.'
 
     def __init__(self, union_types, union_type_context):
         self._union_types = union_types
         self._union_type_context = union_type_context
         self.is_valid = False
-        self.errors = []
+        self.error_messages = None
 
     @abstractmethod
     def validate(self, value):

--- a/apimatic_core_interfaces/types/union_type.py
+++ b/apimatic_core_interfaces/types/union_type.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from apimatic_core.types.union_types.union_type_context import UnionTypeContext
+
+
+class UnionType(ABC):
+    NATIVE_TYPES = [int, str, float, bool]
+
+    def __init__(self, union_types, union_type_context: UnionTypeContext):
+        self._union_types = union_types
+        self._union_type_context = union_type_context
+        self.is_valid = False
+
+    @abstractmethod
+    def validate(self, value):
+        ...
+
+    @abstractmethod
+    def deserialize(self, value):
+        ...

--- a/apimatic_core_interfaces/types/union_type.py
+++ b/apimatic_core_interfaces/types/union_type.py
@@ -10,7 +10,7 @@ class UnionType(ABC):
         self._union_types = union_types
         self._union_type_context = union_type_context
         self.is_valid = False
-        self.error_messages = None
+        self.error_messages = set()
 
     @abstractmethod
     def validate(self, value):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name='apimatic-core-interfaces',
-    version='0.1.3',
+    version='0.1.4',
     description='An abstract layer of the functionalities provided by apimatic-core-library, requests-client-adapter '
                 'and APIMatic SDKs.',
     long_description=long_description,


### PR DESCRIPTION
This PR adds support for union-types that are OneOf and AnyOf types by providing the base type by the name of the UnionType which is an abstract class. This concrete implementation of this class are OneOf, AnyOf and LeafType classes which are part of the core library.

closes #19