### PR TITLE
docs: compatibility with python 3.12 and 3.13

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
                python -m pip install --upgrade pip
+               pip install -r requirements.txt
                pip install pylint
                pip install pylint-fail-under
       - name: Analysing the code with pylint
@@ -35,5 +36,5 @@ jobs:
         run: |
               for file in $(find -name '*.py')
               do
-               pylint --disable=R,C,W "$file" --fail-under=10;    
+               pylint --disable=R,C,W "$file" --fail-under=10;
               done

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 ## Introduction
 This project contains the abstract layer for APIMatic's core library. The purpose of creating interfaces is to separate out the functionalities needed by APIMatic's core library module. The goal is to support scalability and feature enhancement of the core library and the SDKs along with avoiding any breaking changes by reducing tight coupling between modules through the introduction of interfaces.
 
-## Version supported 
-Currenty APIMatic supports  `Python version 3.7 - 3.11`  hence the apimatic-core-interfaces will need the same versions to be supported.
+## Version supported
+Currenty APIMatic supports  `Python version 3.7+`  hence the apimatic-core-interfaces will need the same versions to be supported.
 
-## Installation 
+## Installation
 Simply run the command below in your SDK as the apimatic-core-interfaces will be added as a dependency in the SDK.
 ```python
 pip install apimatic-core-interfaces

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+setuptools>=68.0.0


### PR DESCRIPTION
## What
- Updated docs to reflect compatibility with python 3.12 and 3.13
- Added setuptools as an explicit dependency.

## Why
This PR was created to match [this PR](https://github.com/apimatic/core-lib-python/pull/85) in the core library.

Previously, setuptools was bundled with Python<=3.11 but has now [been removed](https://github.com/python/cpython/pull/101039) by default. So, we need to add it explicitly in requirements.txt. We should consider adding pyproject.toml to our python repos [as that is now the standard](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-pyproject-toml-mandatory).

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [x] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Testing
See [this PR](https://github.com/apimatic/apimatic-codegen/pull/4096).

## Checklist
- [ ] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
